### PR TITLE
Add phone support

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -67,7 +67,7 @@ function plugin_jamf_install()
                   `lost_location_speed` varchar(100) DEFAULT '',
                   `lost_location_date` datetime NULL,
                 PRIMARY KEY (`id`),
-                UNIQUE KEY `unicity` (`computers_id`),
+                UNIQUE KEY `unicity` (`itemtype`, `items_id`),
                 KEY `udid` (`udid`)
                ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
       $DB->queryOrDie($query, 'Error creating JAMF plugin imports table' . $DB->error());
@@ -92,6 +92,7 @@ function plugin_jamf_uninstall()
 {
    PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_imports');
    PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_mobiledevices');
+   CronTask::unregister('jamf');
    return true;
 }
 

--- a/hook.php
+++ b/hook.php
@@ -43,7 +43,8 @@ function plugin_jamf_install()
    if (!$DB->tableExists('glpi_plugin_jamf_mobiledevices')) {
       $query = "CREATE TABLE `glpi_plugin_jamf_mobiledevices` (
                   `id` int(11) NOT NULL auto_increment,
-                  `computers_id` int(11) NOT NULL,
+                  `items_id` int(11) NOT NULL,
+                  `itemtype` varchar(100) NOT NULL,
                   `udid` varchar(100) NOT NULL,
                   `last_inventory` datetime NULL,
                   `entry_date` datetime NULL,

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -111,7 +111,7 @@ class PluginJamfConfig extends CommonDBTM
          'name' => 'default_manufacturer',
          'value' => $jamf_config['default_manufacturer']]);
       echo "</td><td>".__('iPhone Type:', 'jamf')."</td><td>";
-      Dropdown::show('ComputerType', [
+      Dropdown::show('PhoneType', [
          'name' => 'iphone_type',
          'value' => $jamf_config['iphone_type']]);
       echo "</td></tr><tr><td>".__('iPad Type:', 'jamf')."</td><td>";

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -46,7 +46,7 @@ class PluginJamfConfig extends CommonDBTM
       echo Html::input('jssuser', ['value' => $jamf_config['jssuser']]);
       echo "</td></tr><tr><td>".__('JSS Password:', 'jamf')."</td><td>";
       echo Html::input('jsspassword', ['type' => 'password']);
-      $msg = isset($jamf_config['jsspassword']) ? __('Password set') : '';
+      $msg = (isset($jamf_config['jsspassword']) && strlen($jamf_config['jsspassword'])) ? __('Password set') : '';
       echo "</td><td>{$msg}</td></tr>";
       echo "</table>";
 
@@ -102,6 +102,28 @@ class PluginJamfConfig extends CommonDBTM
       echo "<td>";
       Dropdown::showYesNo('autoimport', $jamf_config['autoimport']);
       echo "</td></tr>";
+
+      echo "<table class='tab_cadre_fixe'><thead>";
+      echo "<th colspan='4'>" . __('Default Type Settings') . "</th></thead>";
+      echo "<td>" . __('Manufacturer:', 'jamf') . "</td>";
+      echo "<td>";
+      Dropdown::show('Manufacturer', [
+         'name' => 'default_manufacturer',
+         'value' => $jamf_config['default_manufacturer']]);
+      echo "</td><td>".__('iPhone Type:', 'jamf')."</td><td>";
+      Dropdown::show('ComputerType', [
+         'name' => 'iphone_type',
+         'value' => $jamf_config['iphone_type']]);
+      echo "</td></tr><tr><td>".__('iPad Type:', 'jamf')."</td><td>";
+      Dropdown::show('ComputerType', [
+         'name' => 'ipad_type',
+         'value' => $jamf_config['ipad_type']]);
+      $msg = isset($jamf_config['jsspassword']) ? __('Password set') : '';
+      echo "</td><td>".__('AppleTV Type', 'jamf')."</td><td>";
+      Dropdown::show('ComputerType', [
+         'name' => 'appletv_type',
+         'value' => $jamf_config['appletv_type']]);
+      echo "</td></tr></table>";
 
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr class='tab_bg_2'>";

--- a/inc/dbutil.class.php
+++ b/inc/dbutil.class.php
@@ -84,7 +84,7 @@
     {
         global $DB;
 
-        $result = $DB->rawQuery(
+        $result = $DB->query(
             $this->buildInsertBulk($table, $columns, $values),
             $values
         );
@@ -106,7 +106,7 @@
         global $DB;
 
         $insert = $this->buildInsertBulk($table, $columns, $values);
-        $res = $DB->rawQuery($insert, $values);
+        $res = $DB->query($insert, $values);
         if (!$res) {
            //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
             $message = sprintf(
@@ -129,14 +129,14 @@
     {
        global $DB;
 
-       return $DB->rawQuery('DROP TABLE'.$DB->quoteName($table));
+       return $DB->query('DROP TABLE'.$DB->quoteName($table));
     }
 
     public static function dropTableOrDie(string $table, string $message = '')
     {
         global $DB;
 
-        $res = $DB->rawQuery('DROP TABLE'.$DB->quoteName($table));
+        $res = $DB->query('DROP TABLE'.$DB->quoteName($table));
         if (!$res) {
            //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
             $message = sprintf(

--- a/inc/mobiledevice.class.php
+++ b/inc/mobiledevice.class.php
@@ -32,14 +32,18 @@ class PluginJamfMobileDevice extends CommonDBTM
       return __('Jamf mobile device', 'Jamf mobile devices', $nb, 'jamf');
    }
 
-   public static function showForComputerMain($params)
+   public static function showForComputerOrPhoneMain($params)
    {
       $item = $params['item'];
-      if ($item::getType() != Computer::getType()) {
+
+      if (!($item::getType() == 'Computer') && !($item::getType() == 'Phone')) {
          return;
       }
       $mobiledevice = new PluginJamfMobileDevice();
-      $match = $mobiledevice->find(['computers_id' => $item->getID()]);
+      $match = $mobiledevice->find([
+         'itemtype' => $item::getType(),
+         'items_id' => $item->getID()]);
+
       if (!count($match)) {
          return;
       }

--- a/inc/mobiledevice.class.php
+++ b/inc/mobiledevice.class.php
@@ -38,7 +38,7 @@ class PluginJamfMobileDevice extends CommonDBTM
       if ($item::getType() != Computer::getType()) {
          return;
       }
-      $mobiledevice = new PluginJamfMobileDevice;
+      $mobiledevice = new PluginJamfMobileDevice();
       $match = $mobiledevice->find(['computers_id' => $item->getID()]);
       if (!count($match)) {
          return;

--- a/inc/shimphoneos.class.php
+++ b/inc/shimphoneos.class.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ -------------------------------------------------------------------------
+ JAMF plugin for GLPI
+ Copyright (C) 2019 by Curtis Conard
+ https://github.com/cconard96/jamf
+ -------------------------------------------------------------------------
+ LICENSE
+ This file is part of JAMF plugin for GLPI.
+ JAMF plugin for GLPI is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ JAMF plugin for GLPI is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with JAMF plugin for GLPI. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ */
+
+/**
+ * Wrapper for Item_OperatingSystem tab for phones since GLPI only shows this tab for Computers, and plugins cannot register a core class to add tabs to items.
+ * @since 1.0.0
+ */
+class PluginJamfShimPhoneOS extends \Item_OperatingSystem {}

--- a/inc/sync.class.php
+++ b/inc/sync.class.php
@@ -122,6 +122,8 @@ class PluginJamfSync extends CommonGLPI {
                   $changes[$itemtype][$item_field] = $general[$jamf_field];
                }
             }
+
+            // Create or match model
             if ($itemtype == 'Phone') {
                $model = new PhoneModel();
             } else {
@@ -137,12 +139,15 @@ class PluginJamfSync extends CommonGLPI {
             } else {
                $model_id = array_keys($model_matches)[0];
             }
+
+            // Set model
             if ($itemtype == 'Computer') {
                $changes[$itemtype]['computermodels_id'] = $model_id;
             } else {
                $changes[$itemtype]['phonemodels_id'] = $model_id;
             }
 
+            // Set default type
             if ($itemtype == 'Phone') {
                $preferred_type = $config['iphone_type'];
                if ($preferred_type) {
@@ -154,7 +159,12 @@ class PluginJamfSync extends CommonGLPI {
                   $changes['computertypes_id'] = $preferred_type;
                }
             }
-            
+
+            // Set default manufacturer
+            $preferred_manufacturer = $config['default_manufacturer'];
+            if ($preferred_manufacturer) {
+               $changes['manufacturers_id'] = $preferred_manufacturer;
+            }
          }
 
          if ($config['sync_software']) {

--- a/setup.php
+++ b/setup.php
@@ -33,6 +33,7 @@ function plugin_init_jamf() {
    $PLUGIN_HOOKS['post_item_form']['jamf'] = ['PluginJamfMobileDevice',
                                                    'showForComputerMain'];
    $PLUGIN_HOOKS['undiscloseConfigValue']['jamf'] = [PluginJamfConfig::class, 'undiscloseConfigValue'];
+   Plugin::registerClass('PluginJamfShimPhoneOS', ['addtabon' => 'Phone']);
 }
 
 function plugin_version_jamf() {

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@ function plugin_init_jamf() {
    $PLUGIN_HOOKS['csrf_compliant']['jamf'] = true;
    Plugin::registerClass('PluginJamfConfig', ['addtabon' => 'Config']);
    $PLUGIN_HOOKS['post_item_form']['jamf'] = ['PluginJamfMobileDevice',
-                                                   'showForComputerMain'];
+                                                   'showForComputerOrPhoneMain'];
    $PLUGIN_HOOKS['undiscloseConfigValue']['jamf'] = [PluginJamfConfig::class, 'undiscloseConfigValue'];
    Plugin::registerClass('PluginJamfShimPhoneOS', ['addtabon' => 'Phone']);
 }


### PR DESCRIPTION
DIfferentiate between different mobile device types:
iPhones - Phone
AppleTVs and iPads - Computer

Currently have to use a shim class to show operating system tab on Phones :(. This can be removed if the core builds in OS support on non-Computer items.