### PR TITLE
Link GLPI User to JSS Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### Added
 - View in Jamf button to mobile device info box in Computers and Phones
-- When merging items, a GLPI item will be preselected if the UUID/UDID or name matches.
- - View in Jamf button to mobile device info box in Computers and Phones
- - When merging items, a GLPI item will be preselected if the UDID/UUID matches (or if the name matches as a backup check)
- - View and sync Extension Attributes
+- When merging items, a GLPI item will be preselected if the UDID/UUID matches (or if the name matches as a backup check)
+- View and sync Extension Attributes
+- Link GLPI users to JSS accounts for privilege checks. This is mandatory for certain actions/sections such as sending MDM commands.
 
 
 ## [1.0.1]

--- a/front/user_jssaccount.form.php
+++ b/front/user_jssaccount.form.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * -------------------------------------------------------------------------
+ * JAMF plugin for GLPI
+ * Copyright (C) 2019 by Curtis Conard
+ * https://github.com/cconard96/jamf
+ * -------------------------------------------------------------------------
+ * LICENSE
+ * This file is part of JAMF plugin for GLPI.
+ * JAMF plugin for GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * JAMF plugin for GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with JAMF plugin for GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * --------------------------------------------------------------------------
+ */
+
+use Glpi\Event;
+include ('../../../inc/includes.php');
+Session::checkRight(PluginJamfUser_JSSAccount::$rightname, UPDATE);
+
+global $DB;
+$result = $DB->updateOrInsert(PluginJamfUser_JSSAccount::getTable(), [
+   'users_id'        => $_POST['users_id'],
+   'jssaccounts_id'  => $_POST['jssaccounts_id']
+], [
+   'users_id'        => $_POST['users_id']
+]);
+if ($result) {
+   Event::log($_POST["users_id"], "user", 2, "security",
+      sprintf(__('%s links a JSS account to a user'), $_SESSION["glpiname"]));
+   Html::back();
+}
+Html::displayErrorAndDie("lost");

--- a/hook.php
+++ b/hook.php
@@ -128,6 +128,15 @@ function plugin_jamf_install()
                ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
         $DB->queryOrDie($query, 'Error creating JAMF plugin item extension field table' . $DB->error());
     }
+    if (!$DB->tableExists('glpi_plugin_jamf_users_jssacounts')) {
+      $query = "CREATE TABLE `glpi_plugin_jamf_users_jssacounts` (
+                  `id` int(11) NOT NULL auto_increment,
+                  `users_id` int(11) NOT NULL,
+                  `jssaccounts_id` int(11) NOT NULL,
+                PRIMARY KEY (`id`)
+               ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
+      $DB->queryOrDie($query, 'Error creating JAMF plugin jss account link table' . $DB->error());
+   }
 
    $jamfconfig = Config::getConfigurationValues('plugin:Jamf');
    if (!count($jamfconfig)) {
@@ -238,6 +247,7 @@ function plugin_jamf_uninstall()
    PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_extensionattributes');
    PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_items_extensionattributes');
    PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_ext_fields');
+   PluginJamfDBUtil::dropTableOrDie('glpi_plugin_jamf_users_jssaccounts');
    Config::deleteConfigurationValues('plugin:Jamf');
    CronTask::unregister('jamf');
    return true;

--- a/inc/apiclassic.class.php
+++ b/inc/apiclassic.class.php
@@ -179,9 +179,10 @@
      * @since 1.0.0
      * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
      * @param array $params API input parameters such as udid, name, or subset.
+     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
      * @return array Associative array of the decoded JSON response.
      */
-    public static function getItems(string $itemtype, array $params = [])
+    public static function getItems(string $itemtype, array $params = [], $user_auth = false)
     {
         $param_str = self::getParamString($params);
         $endpoint = "$itemtype$param_str";
@@ -197,9 +198,10 @@
      * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
      * @param array $params API input parameters such as udid, name, or subset.
      * @param array $fields Associative array of item fields.
+     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
      * @return array Associative array of the decoded JSON response.
      */
-    public static function addItem(string $itemtype, array $params = [], array $fields = [])
+    public static function addItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
     {
         $param_str = self::getParamString($params);
         $endpoint = "$itemtype$param_str";
@@ -213,9 +215,10 @@
      * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
      * @param array $params API input parameters such as udid, name, or subset.
      * @param array $fields Associative array of item fields.
+     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
      * @return array Associative array of the decoded JSON response.
      */
-    public static function updateItem(string $itemtype, array $params = [], array $fields = [])
+    public static function updateItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
     {
         $param_str = self::getParamString($params);
         $endpoint = "$itemtype$param_str";
@@ -228,9 +231,10 @@
      * @since 1.1.0
      * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
      * @param array $params API input parameters such as udid, name, or subset.
+     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
      * @return array Associative array of the decoded JSON response.
      */
-    public static function deleteItem(string $itemtype, array $params = [])
+    public static function deleteItem(string $itemtype, array $params = [], $user_auth = false)
     {
         $param_str = self::getParamString($params);
         $endpoint = "$itemtype$param_str";

--- a/inc/apiclassic.class.php
+++ b/inc/apiclassic.class.php
@@ -25,220 +25,233 @@
  * JSS Classic API interface class
  * @since 1.0.0
  */
- class PluginJamfAPIClassic {
-    /** PluginJamfConnection object representing the connection to a JSS server */
-    private static $connection;
+class PluginJamfAPIClassic
+{
+   /** PluginJamfConnection object representing the connection to a JSS server */
+   private static $connection;
 
-    /**
-     * Get data from a JSS Classic API endpoint.
-     * @since 1.0.0
-     * @param string  $endpoint The API endpoint.
-     * @param bool    $raw If true, data is returned as JSON instead of decoded into an array.
-     * @return mixed JSON string or associative array depending on the value of $raw.
-     */
-    private static function get(string $endpoint, $raw = false)
-    {
-        if (!self::$connection) {
-            self::$connection = new PluginJamfConnection();
-        }
-        $url = (self::$connection)->getAPIUrl($endpoint);
-        $curl = curl_init($url);
-        // Set the username and password in an authentication header
-        self::$connection->setCurlAuth($curl);
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, [
-           'Content-Type: application/json',
-           'Accept: application/json'
-        ]);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        $response = curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
-        if (!$response) {
-           return null;
-        }
-        if ($httpcode == 500) {
-           $response = json_decode($response, true);
-           if (isset($response['fault'])) {
-              $fault = $response['fault'];
-              switch ($fault['detail']['errorcode']) {
-                 case 'policies.ratelimit.QuotaViolation':
-                    // We are making too many API calls in a short time.
-                    throw new PluginJamfRateLimitException($fault['faultstring']);
-              }
-           }
-           throw new RuntimeException(__("Unknown JSS API Error"));
-        } else {
-           return ($raw ? $response : json_decode($response, true));
-        }
-    }
+   /**
+    * Get data from a JSS Classic API endpoint.
+    * @param string $endpoint The API endpoint.
+    * @param bool $raw If true, data is returned as JSON instead of decoded into an array.
+    * @return mixed JSON string or associative array depending on the value of $raw.
+    * @since 1.0.0
+    */
+   private static function get(string $endpoint, $raw = false)
+   {
+      if (!self::$connection) {
+         self::$connection = new PluginJamfConnection();
+      }
+      $url = (self::$connection)->getAPIUrl($endpoint);
+      $curl = curl_init($url);
+      // Set the username and password in an authentication header
+      self::$connection->setCurlAuth($curl);
+      curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+      curl_setopt($curl, CURLOPT_HTTPHEADER, [
+         'Content-Type: application/json',
+         'Accept: application/json'
+      ]);
+      curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+      $response = curl_exec($curl);
+      $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+      curl_close($curl);
+      if (!$response) {
+         return null;
+      }
+      if ($httpcode == 500) {
+         $response = json_decode($response, true);
+         if (isset($response['fault'])) {
+            $fault = $response['fault'];
+            switch ($fault['detail']['errorcode']) {
+               case 'policies.ratelimit.QuotaViolation':
+                  // We are making too many API calls in a short time.
+                  throw new PluginJamfRateLimitException($fault['faultstring']);
+            }
+         }
+         throw new RuntimeException(__("Unknown JSS API Error"));
+      } else {
+         return ($raw ? $response : json_decode($response, true));
+      }
+   }
 
-    /**
-     * Add a new item through a JSS Classic API endpoint.
-     * @since 1.1.0
-     * @param string  $endpoint The API endpoint.
-     * @param array   $data Associative array of data to post to the endpoint.
-     * @return int|bool True if successful, or the HTTP return code if it is not 201.
-     */
-    private static function add(string $endpoint, array $data)
-    {
-        if (!self::$connection) {
-            self::$connection = new PluginJamfConnection();
-        }
-        $url = (self::$connection)->getAPIUrl($endpoint);
-        $curl = curl_init($url);
-        // Set the username and password in an authentication header
-        self::$connection->setCurlAuth($curl);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, [
-           'Content-Type: application/json',
-           'Accept: application/json'
-        ]);
-        curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
-        return ($httpcode == 201) ? true : $httpcode;
-    }
+   /**
+    * Add a new item through a JSS Classic API endpoint.
+    * @param string $endpoint The API endpoint.
+    * @param array $data Associative array of data to post to the endpoint.
+    * @return int|bool True if successful, or the HTTP return code if it is not 201.
+    * @since 1.1.0
+    */
+   private static function add(string $endpoint, array $data)
+   {
+      if (!self::$connection) {
+         self::$connection = new PluginJamfConnection();
+      }
+      $url = (self::$connection)->getAPIUrl($endpoint);
+      $curl = curl_init($url);
+      // Set the username and password in an authentication header
+      self::$connection->setCurlAuth($curl);
+      curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+      curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+      curl_setopt($curl, CURLOPT_HTTPHEADER, [
+         'Content-Type: application/json',
+         'Accept: application/json'
+      ]);
+      curl_exec($curl);
+      $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+      curl_close($curl);
+      return ($httpcode == 201) ? true : $httpcode;
+   }
 
-    /**
-     * Update an item through a JSS Classic API endpoint.
-     * @since 1.1.0
-     * @param string  $endpoint The API endpoint.
-     * @param array   $data Associative array of data to put to the endpoint.
-     * @return int|bool True if successful, or the HTTP return code if it is not 201.
-     */
-    private static function update(string $endpoint, array $data)
-    {
-        if (!self::$connection) {
-            self::$connection = new PluginJamfConnection();
-        }
-        $url = (self::$connection)->getAPIUrl($endpoint);
-        $curl = curl_init($url);
-        // Set the username and password in an authentication header
-        self::$connection->setCurlAuth($curl);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
-        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, [
-           'Content-Type: application/json',
-           'Accept: application/json'
-        ]);
-        curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
-        return ($httpcode == 201) ? true : $httpcode;
-    }
+   /**
+    * Update an item through a JSS Classic API endpoint.
+    * @param string $endpoint The API endpoint.
+    * @param array $data Associative array of data to put to the endpoint.
+    * @return int|bool True if successful, or the HTTP return code if it is not 201.
+    * @since 1.1.0
+    */
+   private static function update(string $endpoint, array $data)
+   {
+      if (!self::$connection) {
+         self::$connection = new PluginJamfConnection();
+      }
+      $url = (self::$connection)->getAPIUrl($endpoint);
+      $curl = curl_init($url);
+      // Set the username and password in an authentication header
+      self::$connection->setCurlAuth($curl);
+      curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+      curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+      curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+      curl_setopt($curl, CURLOPT_HTTPHEADER, [
+         'Content-Type: application/json',
+         'Accept: application/json'
+      ]);
+      curl_exec($curl);
+      $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+      curl_close($curl);
+      return ($httpcode == 201) ? true : $httpcode;
+   }
 
-    /**
-     * Delete an item through a JSS Classic API endpoint.
-     * @since 1.1.0
-     * @param string  $endpoint The API endpoint.
-     * @return int|bool True if successful, or the HTTP return code if it is not 200.
-     */
-    private static function delete(string $endpoint)
-    {
-        if (!self::$connection) {
-            self::$connection = new PluginJamfConnection();
-        }
-        $url = (self::$connection)->getAPIUrl($endpoint);
-        $curl = curl_init($url);
-        // Set the username and password in an authentication header
-        self::$connection->setCurlAuth($curl);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
-        return ($httpcode == 200) ? true : $httpcode;
-    }
+   /**
+    * Delete an item through a JSS Classic API endpoint.
+    * @param string $endpoint The API endpoint.
+    * @return int|bool True if successful, or the HTTP return code if it is not 200.
+    * @since 1.1.0
+    */
+   private static function delete(string $endpoint)
+   {
+      if (!self::$connection) {
+         self::$connection = new PluginJamfConnection();
+      }
+      $url = (self::$connection)->getAPIUrl($endpoint);
+      $curl = curl_init($url);
+      // Set the username and password in an authentication header
+      self::$connection->setCurlAuth($curl);
+      curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+      curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+      curl_exec($curl);
+      $httpcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+      curl_close($curl);
+      return ($httpcode == 200) ? true : $httpcode;
+   }
 
-    /**
-     * Construct a parameter query string for an API endpoint.
-     * @since 1.0.0
-     * @param array $params API inputs.
-     * @return string The constructed parameter string.
-     */
-    private static function getParamString(array $params = [])
-    {
-        $param_str = "";
-        foreach ($params as $key => $value) {
-            $param_str = "{$param_str}/{$key}/{$value}";
-        }
-        return $param_str;
-    }
+   /**
+    * Construct a parameter query string for an API endpoint.
+    * @param array $params API inputs.
+    * @return string The constructed parameter string.
+    * @since 1.0.0
+    */
+   private static function getParamString(array $params = [])
+   {
+      $param_str = "";
+      foreach ($params as $key => $value) {
+         $param_str = "{$param_str}/{$key}/{$value}";
+      }
+      return $param_str;
+   }
 
-    /**
-     * Get data for a specified JSS itemtype and parameters.
-     * @since 1.0.0
-     * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
-     * @param array $params API input parameters such as udid, name, or subset.
-     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
-     * @return array Associative array of the decoded JSON response.
-     */
-    public static function getItems(string $itemtype, array $params = [], $user_auth = false)
-    {
-        $param_str = self::getParamString($params);
-        $endpoint = "$itemtype$param_str";
-        $response = self::get($endpoint);
-        // Strip first key (usually like mobile_devices or mobile_device)
-        // No other first level keys exist
-        return (!is_null($response) && count($response)) ? reset($response) : null;
-    }
+   /**
+    * Get data for a specified JSS itemtype and parameters.
+    * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
+    * @param array $params API input parameters such as udid, name, or subset.
+    * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
+    * @return array Associative array of the decoded JSON response.
+    * @since 1.0.0
+    */
+   public static function getItems(string $itemtype, array $params = [], $user_auth = false)
+   {
+      if ($user_auth && !PluginJamfUser_JSSAccount::canReadJSSItem($itemtype)) {
+         return null;
+      }
+      $param_str = self::getParamString($params);
+      $endpoint = "$itemtype$param_str";
+      $response = self::get($endpoint);
+      // Strip first key (usually like mobile_devices or mobile_device)
+      // No other first level keys exist
+      return (!is_null($response) && count($response)) ? reset($response) : null;
+   }
 
-    /**
-     * Add an item of the specified JSS itemtype and parameters.
-     * @since 1.1.0
-     * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
-     * @param array $params API input parameters such as udid, name, or subset.
-     * @param array $fields Associative array of item fields.
-     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
-     * @return array Associative array of the decoded JSON response.
-     */
-    public static function addItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
-    {
-        $param_str = self::getParamString($params);
-        $endpoint = "$itemtype$param_str";
-        $response = self::add($endpoint, $fields);
-        return $response;
-    }
+   /**
+    * Add an item of the specified JSS itemtype and parameters.
+    * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
+    * @param array $params API input parameters such as udid, name, or subset.
+    * @param array $fields Associative array of item fields.
+    * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
+    * @return array Associative array of the decoded JSON response.
+    * @since 1.1.0
+    */
+   public static function addItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
+   {
+      if ($user_auth && !PluginJamfUser_JSSAccount::canCreateJSSItem($itemtype)) {
+         return null;
+      }
+      $param_str = self::getParamString($params);
+      $endpoint = "$itemtype$param_str";
+      $response = self::add($endpoint, $fields);
+      return $response;
+   }
 
-    /**
-     * Update an item of the specified JSS itemtype and parameters.
-     * @since 1.1.0
-     * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
-     * @param array $params API input parameters such as udid, name, or subset.
-     * @param array $fields Associative array of item fields.
-     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
-     * @return array Associative array of the decoded JSON response.
-     */
-    public static function updateItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
-    {
-        $param_str = self::getParamString($params);
-        $endpoint = "$itemtype$param_str";
-        $response = self::update($endpoint, $fields);
-        return $response;
-    }
+   /**
+    * Update an item of the specified JSS itemtype and parameters.
+    * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
+    * @param array $params API input parameters such as udid, name, or subset.
+    * @param array $fields Associative array of item fields.
+    * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
+    * @return array Associative array of the decoded JSON response.
+    * @since 1.1.0
+    */
+   public static function updateItem(string $itemtype, array $params = [], array $fields = [], $user_auth = false)
+   {
+      if ($user_auth && !PluginJamfUser_JSSAccount::canUpdateJSSItem($itemtype)) {
+         return null;
+      }
+      $param_str = self::getParamString($params);
+      $endpoint = "$itemtype$param_str";
+      $response = self::update($endpoint, $fields);
+      return $response;
+   }
 
-    /**
-     * Delete an item of the specified JSS itemtype and parameters.
-     * @since 1.1.0
-     * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
-     * @param array $params API input parameters such as udid, name, or subset.
-     * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
-     * @return array Associative array of the decoded JSON response.
-     */
-    public static function deleteItem(string $itemtype, array $params = [], $user_auth = false)
-    {
-        $param_str = self::getParamString($params);
-        $endpoint = "$itemtype$param_str";
-        $response = self::delete($endpoint);
-        return $response;
-    }
+   /**
+    * Delete an item of the specified JSS itemtype and parameters.
+    * @param string $itemtype The type of data to fetch. This matches up with endpoint names.
+    * @param array $params API input parameters such as udid, name, or subset.
+    * @param bool $user_auth True if the user's linked JSS account privileges should be checked for requested resource.
+    * @return array Associative array of the decoded JSON response.
+    * @since 1.1.0
+    */
+   public static function deleteItem(string $itemtype, array $params = [], $user_auth = false)
+   {
+      if ($user_auth && !PluginJamfUser_JSSAccount::canDeleteJSSItem($itemtype)) {
+         return null;
+      }
+      $param_str = self::getParamString($params);
+      $endpoint = "$itemtype$param_str";
+      $response = self::delete($endpoint);
+      return $response;
+   }
 }

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -74,7 +74,10 @@ class PluginJamfProfile extends Profile {
                             'field'     => 'plugin_jamf_mobiledevice'],
                       ['itemtype'  => 'PluginJamfRuleImport',
                             'label'     => _n('Import rule', 'Import rules', Session::getPluralNumber(), 'jamf'),
-                            'field'     => 'plugin_jamf_ruleimport']];
+                            'field'     => 'plugin_jamf_ruleimport'],
+                      ['itemtype'  => 'PluginJamfUser_JSSAccount',
+                         'label'     => PluginJamfUser_JSSAccount::getTypeName(Session::getPluralNumber()),
+                         'field'     => PluginJamfUser_JSSAccount::$rightname]];
       $matrix_options['title'] = __('Jamf Plugin');
       $profile->displayRightsChoiceMatrix($rights, $matrix_options);
 

--- a/inc/user_jssaccount.class.php
+++ b/inc/user_jssaccount.class.php
@@ -194,7 +194,8 @@ class PluginJamfUser_JSSAccount extends CommonDBChild {
       ]);
       echo "</td><td></td><td></td></td></tr><tr><td class='tab_bg_2 center' colspan='4'>";
       if ($canedit) {
-         echo "<input type='submit' name='update' value='" . _sx('button', 'Save') . "' class='submit'/>";
+         $title = __('Update account link', 'jamf');
+         echo "<input title='{$title}' type='submit' name='update' value='" . _sx('button', 'Save') . "' class='submit'/>";
       }
       echo "</td></tr></table>";
       if ($canedit) {

--- a/inc/user_jssaccount.class.php
+++ b/inc/user_jssaccount.class.php
@@ -64,11 +64,93 @@ class PluginJamfUser_JSSAccount extends CommonDBChild {
       return $jssaccount[$this->fields['jssusers_id']]['privileges'] ?? [];
    }
 
+   private static function getItemRightMap() {
+      static $map = null;
+      if ($map === null) {
+         $map = [
+            'accounts' => ['Accounts'],
+            'advancedcomputersearches' => ['Advanced Computer Searches'],
+            'advancedmobiledevicesearches' => ['Advanced Mobile Device Searches'],
+            'advancedusersearches' => ['Advanced User Searches'],
+            'buildings' => ['Buildings'],
+            'categories' => ['Categories'],
+            'classes' => ['Classes'],
+            'departments' => ['Departments'],
+            'mobiledeviceapplications' => ['Mobile Device Applications'],
+            'mobiledeviceextensionattributes' => ['Mobile Device Extension Attributes'],
+            'mobiledevicegroups' => ['Smart Mobile Device Groups', 'Static Mobile Device Groups'],
+            'mobiledevices' => ['Mobile Devices'],
+            'users' => ['Users'],
+         ];
+      }
+      return $map;
+   }
+
+   public static function canCreateJSSItem($itemtype) {
+      $map = self::getItemRightMap();
+      if (!isset($map[$itemtype])) {
+         return false;
+      }
+      $rights = $map[$itemtype];
+      foreach ($rights as $right) {
+         if (!self::haveJSSRight('jss_objects', 'Create '.$right)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   public static function canReadJSSItem($itemtype) {
+      $map = self::getItemRightMap();
+      if (!isset($map[$itemtype])) {
+         return false;
+      }
+      $rights = $map[$itemtype];
+      foreach ($rights as $right) {
+         if (!self::haveJSSRight('jss_objects', 'Read '.$right)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   public static function canUpdateJSSItem($itemtype) {
+      $map = self::getItemRightMap();
+      if (!isset($map[$itemtype])) {
+         return false;
+      }
+      $rights = $map[$itemtype];
+      foreach ($rights as $right) {
+         if (!self::haveJSSRight('jss_objects', 'Update '.$right)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   public static function canDeleteJSSItem($itemtype) {
+      $map = self::getItemRightMap();
+      if (!isset($map[$itemtype])) {
+         return false;
+      }
+      $rights = $map[$itemtype];
+      foreach ($rights as $right) {
+         if (!self::haveJSSRight('jss_objects', 'Delete '.$right)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
    public static function haveJSSRight($type, $jss_right) {
       $user_jssaccount = new self();
-      $matches = $user_jssaccount->find([
-         'users_id'  => Session::getLoginUserID()
-      ]);
+      static $matches = null;
+
+      if ($matches === null) {
+         $matches = $user_jssaccount->find([
+            'users_id' => Session::getLoginUserID()
+         ]);
+      }
       if (count($matches) === 0) {
          // No JSS account link
          return false;

--- a/setup.php
+++ b/setup.php
@@ -40,6 +40,7 @@ function plugin_init_jamf() {
        'Computer',
        'Phone'
    ]]);
+   Plugin::registerClass('PluginJamfUser_JSSAccount', ['addtabon' => ['User']]);
    if (Session::haveRight('plugin_jamf_mobiledevice', READ)) {
       $PLUGIN_HOOKS['menu_toadd']['jamf'] = ['tools' => 'PluginJamfMenu'];
    }


### PR DESCRIPTION
As I start to add features that interact with JSS beyond reading basic inventory data, it is imperative that GLPI users are still restricted based on their own JSS accounts.

It is planned to use the global JSS account for retrieving all data, but commands and other actions must be tested against JSS permissions of the current user's linked account. If no account is linked, they only have access to basic inventory data (based on profile rights).