### PR TITLE
Add Schedule iOS/iPadOS Update Command

### DIFF
--- a/inc/mdmcommand.class.php
+++ b/inc/mdmcommand.class.php
@@ -244,6 +244,30 @@ class PluginJamfMDMCommand {
                   'supervised'   => true
                ]
             ]
+            'ScheduleOSUpdate'   => [
+               'name'         => __('Schedule OS update', 'jamf'),
+               'icon'         => 'fas fa-arrow-up',
+               'jss_right'    => 'Send Mobile Device Remote Command to Download and Install iOS Update',
+               'confirm'      => true,
+               'requirements' => [
+                  'devicetypes'  => ['mobiledevice'],
+                  'managed'      => true,
+                  'supervised'   => true
+               ],
+               'params' => [
+                  'install_action'  => [
+                     'name'   => __('Install action', 'jamf'),
+                     'type'   => 'dropdown',
+                     'values' => [
+                        '1'   => __('Download and prompt for install', 'jamf'),
+                        '2'   => __('Download, install, and restart', 'jamf')
+                     ]
+                  ],
+                  'product_version' => [
+                     'name'   => __('Product version', 'jamf'),
+                     'type'   => 'string',
+                  ]
+               ]
          ];
       }
       return $allcommands;
@@ -279,6 +303,10 @@ class PluginJamfMDMCommand {
                   $out .= " checked='checked'";
                }
                $out .= "/>";
+            } else if ($fieldtype === 'dropdown') {
+               $out .= Dropdown::showFromArray($name, $params['values'], [
+                  'display'   => false
+               ]);
             } else {
                $out .= "<input title='$displayname' name='$name' type='text'/>";
             }


### PR DESCRIPTION
Allow updating a single iOS/iPadOS device. You can specify the target version using the full semantic version number such as "13.1.3". We cannot give the option of using the latest valid version, or listing all valid/signed versions here unless we find an API that we can fetch this info from (Maybe something directly from Apple or a third-party like IPSW.me).