### PR TITLE
Bump requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Syncs data from JAMF Pro to GLPI.
 Only supports mobile devices for now.
 
 ## Requirements
-- GLPI >= 9.4.0
-- PHP >= 7.0.0 (Notice this differs from GLPI requirements)
-- Jamf Pro >= 10.9.0
-- php simplexml extension. run "composer require ext-simplexml --ignore-platform-reqs" in the root of the site to install the newest version for PHP 7 and ignore GLPI's lower required PHP version.
+- GLPI >= 9.5.0
+- PHP >= 7.2.0
+- Jamf Pro >= 10.20.0
+- php simplexml extension. run "composer require ext-simplexml" in the root of the site to install the newest version.
 
 ## Usage
 - Server/sync configuration is found in Setup > Config under the JAMF Plugin tab.


### PR DESCRIPTION
Bump minimum version requirement of GLPI to 9.5.
Bump PHP requirement to 7.2 to match GLPI 9.5's requirement.
Drop support for Jamf Pro below version 10.20. There are no known issues with 10.9 - 10.19, but they will not be explicitly coded for anymore.
