### PR TITLE
Add default status for Jamf devices

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -211,6 +211,14 @@ function plugin_jamf_install()
       'context'   => 'plugin:Jamf',
       'name'      => 'itemtype_appletv'
    ]);
+
+   if (!count(Config::getConfigurationValues('plugin:Jamf', ['default_status']))) {
+      $DB->insertOrDie('glpi_configs', [
+         'context'   => 'plugin:Jamf',
+         'name'      => 'default_status',
+         'value'     => null
+      ]);
+   }
    // End of Post-release configs
 
    CronTask::register('PluginJamfSync', 'syncJamf', 300, [

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -118,7 +118,7 @@ class PluginJamfConfig extends CommonDBTM
       echo "</td></tr>";
 
       echo "<table class='tab_cadre_fixe'><thead>";
-      echo "<th colspan='4'>" . __('Default Type Settings') . "</th></thead>";
+      echo "<th colspan='4'>" . __('Default Settings') . "</th></thead>";
       echo "<td>" . __('Manufacturer', 'jamf') . "</td>";
       echo "<td>";
       Dropdown::show('Manufacturer', [
@@ -140,7 +140,21 @@ class PluginJamfConfig extends CommonDBTM
          'name' => 'appletv_type',
          'value' => isset($config['appletv_type']) ? $config['appletv_type'] : false
       ]);
-      echo "</td></tr></table>";
+      echo "</td></tr>";
+
+      echo "<tr><td>".__('Default status', 'jamf')."</td><td>";
+      State::dropdown([
+         'name'      => 'default_status',
+         'value'     => $config['default_status'],
+         'entity'    => 0,
+         'condition' => [
+            'is_visible_computer'   => 1,
+            'is_visible_phone'      => 1
+         ],
+      ]);
+      echo "</td><td></td></tr>";
+
+      echo "</table>";
 
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr class='tab_bg_2'>";

--- a/inc/sync.class.php
+++ b/inc/sync.class.php
@@ -290,6 +290,10 @@ class PluginJamfSync extends CommonGLPI
          if ($preferred_manufacturer) {
             $this->item_changes['manufacturers_id'] = $preferred_manufacturer;
          }
+
+         if ($this->item === null || $this->item->fields['states_id'] === 0) {
+            $this->item_changes['states_id'] = $config['default_status'];
+         }
       } catch (Exception $e) {
          $this->status['syncGeneral'] = self::STATUS_ERROR;
          return $this;


### PR DESCRIPTION
Assign default status for newly imported devices and merged devices that have no status already set.