### PR TITLE
Abstract device sync more and move common functions

### DIFF
--- a/inc/abstractdevice.class.php
+++ b/inc/abstractdevice.class.php
@@ -48,7 +48,7 @@ abstract class PluginJamfAbstractDevice extends CommonDBChild
 
    /**
     * Cleanup relations when an item is purged.
-    * @global type $DB
+    * @global DBmysql $DB
     * @param CommonDBTM $item
     */
    private static function purgeItemCommon(CommonDBTM $item)

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -28,7 +28,7 @@ class PluginJamfComputer extends PluginJamfAbstractDevice
 {
    static $rightname = 'plugin_jamf_computer';
 
-   public static $jamftype_name = 'computers';
+   public static $jamftype_name = 'Computer';
 
    public static function getTypeName($nb = 1)
    {

--- a/inc/devicesync.class.php
+++ b/inc/devicesync.class.php
@@ -1,0 +1,275 @@
+<?php
+
+/*
+ -------------------------------------------------------------------------
+ JAMF plugin for GLPI
+ Copyright (C) 2019-2020 by Curtis Conard
+ https://github.com/cconard96/jamf
+ -------------------------------------------------------------------------
+ LICENSE
+ This file is part of JAMF plugin for GLPI.
+ JAMF plugin for GLPI is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ JAMF plugin for GLPI is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with JAMF plugin for GLPI. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ */
+
+abstract class PluginJamfDeviceSync extends PluginJamfSync {
+
+   /**
+    * Sync general information such as name, serial number, etc.
+    * All synced fields here are on the main GLPI item and not a plugin item type.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncGeneral(): PluginJamfDeviceSync
+   {
+      $this->status['syncGeneral'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync operating system information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncOS(): PluginJamfDeviceSync
+   {
+      $this->status['syncOS'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync software information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncSoftware(): PluginJamfDeviceSync
+   {
+      $this->status['syncSoftware'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync user information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncUser(): PluginJamfDeviceSync
+   {
+      $this->status['syncUser'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync purchasing information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncPurchasing(): PluginJamfDeviceSync
+   {
+      $this->status['syncPurchasing'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync extension attributes. This task will be deferred if run for a device that was not previously imported.
+    * @return PluginJamfDeviceSync
+    * @since 1.1.0
+    */
+   protected function syncExtensionAttributes(): PluginJamfDeviceSync
+   {
+      $this->status['syncExtensionAttributes'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync security information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncSecurity(): PluginJamfDeviceSync
+   {
+      $this->status['syncSecurity'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync network information.
+    * @return PluginJamfDeviceSync
+    * @since 2.0.0
+    */
+   protected function syncNetwork(): PluginJamfDeviceSync
+   {
+      $this->status['syncNetwork'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync general Jamf device information. All changes are made for the Jamf plugin item only. No GLPI item changes are made here.
+    * @since 1.1.0
+    * @return PluginJamfDeviceSync
+    */
+   protected function syncGeneralJamfPluginItem(): PluginJamfDeviceSync
+   {
+      $this->status['syncGeneralJamfPluginItem'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   /**
+    * Sync component information such as volumes.
+    * @since 2.0.0
+    * @return PluginJamfDeviceSync
+    */
+   protected function syncComponents(): PluginJamfDeviceSync
+   {
+      $this->status['syncComponents'] = self::STATUS_NOT_APPLICABLE;
+      return $this;
+   }
+
+   public static function syncExtensionAttributeDefinitions(): void
+   {
+      switch (static::$jamf_itemtype) {
+         case 'Computer':
+            $api_itemtype = 'computerextensionattributes';
+            break;
+         case 'MobileDevice':
+            $api_itemtype = 'mobiledeviceextensionattributes';
+            break;
+         default:
+            $api_itemtype = null;
+      }
+      if ($api_itemtype === null) {
+         return;
+      }
+      $ext_attr = new PluginJamfExtensionAttribute();
+      $all_attributes = PluginJamfAPIClassic::getItems($api_itemtype);
+      if (is_array($all_attributes)) {
+         foreach ($all_attributes as $attribute) {
+            $attr = PluginJamfAPIClassic::getItems($api_itemtype, ['id' => $attribute['id']]);
+            $input = [
+               'jamf_id'      => $attr['id'],
+               'itemtype'     => static::$jamfplugin_itemtype::getType(),
+               'jamf_type'    => static::$jamf_itemtype,
+               'name'         => $attr['name'],
+               'description'  => $attr['description'],
+               'data_type'    => $attr['data_type']
+            ];
+            $ext_attr->addOrUpdate($input);
+         }
+      }
+   }
+
+   public static function syncAll(): int
+   {
+      global $DB;
+
+      $volume = 0;
+
+      $config = PluginJamfConfig::getConfig();
+
+      static::syncExtensionAttributeDefinitions();
+      $iterator = $DB->request([
+         'SELECT' => ['itemtype', 'items_id'],
+         'FROM' => (static::$jamfplugin_itemtype)::getTable(),
+         'WHERE' => [
+            new QueryExpression("sync_date < NOW() - INTERVAL {$config['sync_interval']} MINUTE")
+         ]
+      ]);
+      if (!$iterator->count()) {
+         return -1;
+      }
+      while ($data = $iterator->next()) {
+         try {
+            $result = self::sync($data['itemtype'], $data['items_id']);
+            if ($result) {
+               $volume++;
+            }
+         } catch (Exception $e2) {
+            // Some other error
+         }
+      }
+      return $volume;
+   }
+
+   /**
+    * Updates a device from data received from the Jamf API. The item must already exist in GLPI and be linked.
+    * @param string $itemtype
+    * @param int $items_id
+    * @param bool $use_transaction True if a DB transaction should be used.
+    * @return bool True if the update was successful.
+    * @throws Exception Any exception that occurs during the update process.
+    */
+   final public static function sync(string $itemtype, int $items_id, bool $use_transaction = true): bool
+   {
+      global $DB;
+
+      $item = new $itemtype();
+
+      if (!$item->getFromDB($items_id)) {
+         Toolbox::logError("Attempted to sync non-existent $itemtype with ID {$items_id}");
+         return false;
+      }
+
+      $data = static::getJamfDataForSyncingByGlpiItem($itemtype, $items_id);
+      if ($data === null) {
+         // API error or device no longer exists in Jamf
+         return false;
+      }
+
+      try {
+         if ($use_transaction) {
+            $DB->beginTransaction();
+         }
+
+         $sync = new static($item, $data);
+         $sync_result = $sync->syncGeneral()
+            ->syncOS()
+            ->syncSoftware()
+            ->syncUser()
+            ->syncPurchasing()
+            ->syncExtensionAttributes()
+            ->syncSecurity()
+            ->syncNetwork()
+            ->syncComponents()
+            ->syncOther()
+            ->syncGeneralJamfPluginItem()
+            ->finalizeSync();
+         // Evaluate final sync result. If any errors exist, count as failure.
+         // Any tasks that are still deferred are also counted as failures.
+         $failed = array_keys($sync_result, [self::STATUS_ERROR, self::STATUS_DEFERRED]);
+         if (count($failed) !== 0) {
+            throw new RuntimeException('One or more sync actions failed [' . implode(', ', $failed) . ']');
+         }
+
+         if ($use_transaction) {
+            $DB->commit();
+         }
+         return true;
+      } catch (Exception $e) {
+         Toolbox::logError($e->getMessage());
+         if ($use_transaction) {
+            $DB->rollBack();
+         }
+         return false;
+      }
+   }
+
+   /**
+    * Sync all other data not handled by the built-in {@link \PluginJamfDeviceSync} sync methods.
+    *
+    * @return PluginJamfDeviceSync
+    * @since 1.0.0
+    */
+   protected function syncOther(): PluginJamfDeviceSync
+   {
+      return $this;
+   }
+}

--- a/inc/mobiledevice.class.php
+++ b/inc/mobiledevice.class.php
@@ -29,7 +29,7 @@ class PluginJamfMobileDevice extends PluginJamfAbstractDevice
 {
    public static $rightname = 'plugin_jamf_mobiledevice';
 
-   public static $jamftype_name = 'mobiledevices';
+   public static $jamftype_name = 'MobileDevice';
 
    public static function getTypeName($nb = 1)
    {

--- a/inc/mobilesync.class.php
+++ b/inc/mobilesync.class.php
@@ -21,22 +21,14 @@
  --------------------------------------------------------------------------
  */
 
-class PluginJamfMobileSync extends PluginJamfSync {
+use Glpi\Event;
 
-   protected $jamfitemtype = 'PluginJamfMobileDevice';
+class PluginJamfMobileSync extends PluginJamfDeviceSync {
 
-   /**
-    * Sync general information such as name, serial number, etc.
-    * All synced fields here are on the main GLPI item and not a plugin item type.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncGeneral(): \PluginJamfMobileSync
+   protected static $jamfplugin_itemtype = 'PluginJamfMobileDevice';
+
+   protected function syncGeneral(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncGeneral'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_general'] || $this->item === null || !isset($this->data['general'])) {
          $this->status['syncGeneral'] = self::STATUS_SKIPPED;
          return $this;
@@ -120,17 +112,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync operating system information.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncOS(): \PluginJamfMobileSync
+   protected function syncOS(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncOS'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_os'] || $this->item === null || !isset($this->data['general'])) {
          $this->status['syncOS'] = self::STATUS_SKIPPED;
          return $this;
@@ -167,17 +150,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync software information.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncSoftware(): \PluginJamfMobileSync
+   protected function syncSoftware(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncSoftware'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_software'] || $this->item === null || !isset($this->data['applications'])) {
          $this->status['syncSoftware'] = self::STATUS_SKIPPED;
          return $this;
@@ -250,18 +224,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync user information.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncUser(): \PluginJamfMobileSync
+   protected function syncUser(): PluginJamfDeviceSync
    {
-
-      if ($this->dummySync) {
-         $this->status['syncUser'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_user'] || $this->item === null || !isset($this->data['location'])) {
          $this->status['syncUser'] = self::STATUS_SKIPPED;
          return $this;
@@ -281,17 +245,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync purchasing information.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncPurchasing(): \PluginJamfMobileSync
+   protected function syncPurchasing(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncPurchasing'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_financial'] || $this->item === null || !isset($this->data['purchasing'])) {
          $this->status['syncPurchasing'] = self::STATUS_SKIPPED;
          return $this;
@@ -330,21 +285,12 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync extension attributes. This task will be deferred if run for a device that was not previously imported.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncExtensionAttributes(): \PluginJamfMobileSync
+   protected function syncExtensionAttributes(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncExtensionAttributes'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_general'] || !isset($this->data['extension_attributes'])) {
          $this->status['syncExtensionAttributes'] = self::STATUS_SKIPPED;
          return $this;
-      } else if ($this->config['sync_general'] && $this->jamfdevice === null) {
+      } else if ($this->config['sync_general'] && $this->jamfplugin_device === null) {
          $this->status['syncExtensionAttributes'] = self::STATUS_DEFERRED;
          return $this;
       }
@@ -355,7 +301,7 @@ class PluginJamfMobileSync extends PluginJamfSync {
          foreach ($extension_attributes as $attr) {
             $attr_match = $ext_attribute->find([
                'jamf_id' => $attr['id'],
-               'itemtype' => $this->jamfdevice::getType(),
+               'itemtype' => $this->jamfplugin_device::getType(),
                'jamf_type' => 'MobileDevice'
             ], [], 1);
 
@@ -363,8 +309,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
                $attr_match = reset($attr_match);
                $this->db->updateOrInsert(PluginJamfItem_ExtensionAttribute::getTable(), ['value' => $attr['value']], [
                   'glpi_plugin_jamf_extensionattributes_id' => $attr_match['id'],
-                  'items_id' => $this->jamfdevice->getID(),
-                  'itemtype' => $this->jamfdevice::getType()
+                  'items_id' => $this->jamfplugin_device->getID(),
+                  'itemtype' => $this->jamfplugin_device::getType()
                ]);
             }
          }
@@ -376,17 +322,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync security information.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncSecurity(): \PluginJamfMobileSync
+   protected function syncSecurity(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncSecurity'] = self::STATUS_ERROR;
-         return $this;
-      }
       if ($this->item === null || !isset($this->data['security'])) {
          $this->status['syncSecurity'] = self::STATUS_SKIPPED;
          return $this;
@@ -395,21 +332,21 @@ class PluginJamfMobileSync extends PluginJamfSync {
          $security = $this->data['security'];
          if (!empty($security['lost_mode_enable_issued_utc'])) {
             $lost_mode_enable_date = PluginJamfToolbox::utcToLocal(new DateTime($security['lost_mode_enable_issued_utc']));
-            $this->jamfdevice_changes['lost_mode_enable_date'] = $lost_mode_enable_date->format("Y-m-d H:i:s");
+            $this->jamfplugin_item_changes['lost_mode_enable_date'] = $lost_mode_enable_date->format("Y-m-d H:i:s");
          }
          if (!empty($security['lost_location_utc'])) {
             $lost_location_date = PluginJamfToolbox::utcToLocal(new DateTime($security['lost_location_utc']));
-            $this->jamfdevice_changes['lost_location_date'] = $lost_location_date->format("Y-m-d H:i:s");
+            $this->jamfplugin_item_changes['lost_location_date'] = $lost_location_date->format("Y-m-d H:i:s");
          }
-         $this->jamfdevice_changes['activation_lock_enabled'] = $security['activation_lock_enabled'];
-         $this->jamfdevice_changes['lost_mode_enabled'] = $security['lost_mode_enabled'];
-         $this->jamfdevice_changes['lost_mode_enforced'] = $security['lost_mode_enforced'];
-         $this->jamfdevice_changes['lost_mode_message'] = $security['lost_mode_message'];
-         $this->jamfdevice_changes['lost_mode_phone'] = $security['lost_mode_phone'];
-         $this->jamfdevice_changes['lost_location_latitude'] = $security['lost_location_latitude'];
-         $this->jamfdevice_changes['lost_location_longitude'] = $security['lost_location_longitude'];
-         $this->jamfdevice_changes['lost_location_altitude'] = $security['lost_location_altitude'];
-         $this->jamfdevice_changes['lost_location_speed'] = $security['lost_location_speed'];
+         $this->jamfplugin_item_changes['activation_lock_enabled'] = $security['activation_lock_enabled'];
+         $this->jamfplugin_item_changes['lost_mode_enabled'] = $security['lost_mode_enabled'];
+         $this->jamfplugin_item_changes['lost_mode_enforced'] = $security['lost_mode_enforced'];
+         $this->jamfplugin_item_changes['lost_mode_message'] = $security['lost_mode_message'];
+         $this->jamfplugin_item_changes['lost_mode_phone'] = $security['lost_mode_phone'];
+         $this->jamfplugin_item_changes['lost_location_latitude'] = $security['lost_location_latitude'];
+         $this->jamfplugin_item_changes['lost_location_longitude'] = $security['lost_location_longitude'];
+         $this->jamfplugin_item_changes['lost_location_altitude'] = $security['lost_location_altitude'];
+         $this->jamfplugin_item_changes['lost_location_speed'] = $security['lost_location_speed'];
       } catch (Exception $e) {
          $this->status['syncSecurity'] = self::STATUS_ERROR;
          return $this;
@@ -418,17 +355,8 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync network information.
-    * @since 1.2.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncNetwork(): \PluginJamfMobileSync
+   protected function syncNetwork(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncNetwork'] = self::STATUS_ERROR;
-         return $this;
-      }
       if ($this->item === null || !isset($this->data['general'])) {
          $this->status['syncNetwork'] = self::STATUS_SKIPPED;
          return $this;
@@ -563,62 +491,43 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return $this;
    }
 
-   /**
-    * Sync general Jamf device information. All changes are made for the Jamf plugin item only. No GLPI item changes are made here.
-    * @since 1.1.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncGeneralJamf(): \PluginJamfMobileSync
+   protected function syncGeneralJamfPluginItem(): PluginJamfDeviceSync
    {
-
-      if ($this->dummySync) {
-         $this->status['syncGeneralJamf'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_general'] || $this->item === null || !isset($this->data['general'])) {
-         $this->status['syncGeneralJamf'] = self::STATUS_SKIPPED;
+         $this->status['syncGeneralJamfPluginItem'] = self::STATUS_SKIPPED;
          return $this;
       }
       try {
          $general = $this->data['general'];
          if (!empty($general['last_inventory_update_utc'])) {
             $last_inventory = PluginJamfToolbox::utcToLocal(new DateTime($general['last_inventory_update_utc']));
-            $this->jamfdevice_changes['last_inventory'] = $last_inventory->format("Y-m-d H:i:s");
+            $this->jamfplugin_item_changes['last_inventory'] = $last_inventory->format("Y-m-d H:i:s");
          }
          if (!empty($general['initial_entry_date_utc'])) {
             $entry_date = PluginJamfToolbox::utcToLocal(new DateTime($general['initial_entry_date_utc']));
-            $this->jamfdevice_changes['entry_date'] = $entry_date->format("Y-m-d H:i:s");
+            $this->jamfplugin_item_changes['entry_date'] = $entry_date->format("Y-m-d H:i:s");
          }
          if (!empty($general['last_enrollment_utc'])) {
             $enroll_date = PluginJamfToolbox::utcToLocal(new DateTime($general['last_enrollment_utc']));
-            $this->jamfdevice_changes['enroll_date'] = $enroll_date->format("Y-m-d H:i:s");
+            $this->jamfplugin_item_changes['enroll_date'] = $enroll_date->format("Y-m-d H:i:s");
          }
 
-         $this->jamfdevice_changes['jamf_items_id'] = $general['id'];
-         $this->jamfdevice_changes['udid'] = $general['udid'];
-         $this->jamfdevice_changes['managed'] = $general['managed'];
-         $this->jamfdevice_changes['supervised'] = $general['supervised'];
-         $this->jamfdevice_changes['shared'] = $general['shared'];
-         $this->jamfdevice_changes['cloud_backup_enabled'] = $general['cloud_backup_enabled'];
+         $this->jamfplugin_item_changes['jamf_items_id'] = $general['id'];
+         $this->jamfplugin_item_changes['udid'] = $general['udid'];
+         $this->jamfplugin_item_changes['managed'] = $general['managed'];
+         $this->jamfplugin_item_changes['supervised'] = $general['supervised'];
+         $this->jamfplugin_item_changes['shared'] = $general['shared'];
+         $this->jamfplugin_item_changes['cloud_backup_enabled'] = $general['cloud_backup_enabled'];
       } catch (Exception $e) {
-         $this->status['syncGeneralJamf'] = self::STATUS_ERROR;
+         $this->status['syncGeneralJamfPluginItem'] = self::STATUS_ERROR;
          return $this;
       }
-      $this->status['syncGeneralJamf'] = self::STATUS_OK;
+      $this->status['syncGeneralJamfPluginItem'] = self::STATUS_OK;
       return $this;
    }
 
-   /**
-    * Sync component information such as volumes.
-    * @since 2.0.0
-    * @return PluginJamfMobileSync
-    */
-   protected function syncComponents(): \PluginJamfMobileSync
+   protected function syncComponents(): PluginJamfDeviceSync
    {
-      if ($this->dummySync) {
-         $this->status['syncComponents'] = self::STATUS_ERROR;
-         return $this;
-      }
       if (!$this->config['sync_components'] || $this->item === null || !isset($this->data['general'])) {
          $this->status['syncComponents'] = self::STATUS_SKIPPED;
          return $this;
@@ -679,26 +588,6 @@ class PluginJamfMobileSync extends PluginJamfSync {
       }
       $this->status['syncComponents'] = self::STATUS_OK;
       return $this;
-   }
-
-   public static function syncExtensionAttributeDefinitions()
-   {
-      $ext_attr = new PluginJamfExtensionAttribute();
-      $all_attributes = PluginJamfAPIClassic::getItems('mobiledeviceextensionattributes');
-      if (is_array($all_attributes)) {
-         foreach ($all_attributes as $attribute) {
-            $attr = PluginJamfAPIClassic::getItems('mobiledeviceextensionattributes', ['id' => $attribute['id']]);
-            $input = [
-               'jamf_id'      => $attr['id'],
-               'itemtype'     => PluginJamfMobileDevice::getType(),
-               'jamf_type'    => 'MobileDevice',
-               'name'         => $attr['name'],
-               'description'  => $attr['description'],
-               'data_type'    => $attr['data_type']
-            ];
-            $ext_attr->addOrUpdate($input);
-         }
-      }
    }
 
    public static function discover(): bool
@@ -826,7 +715,7 @@ class PluginJamfMobileSync extends PluginJamfSync {
       }
       if ($iterator->count()) {
          // Already imported
-         \Glpi\Event::log(-1, $itemtype, 4, 'Jamf plugin', "Jamf mobile device $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
+         Event::log(-1, $itemtype, 4, 'Jamf plugin', "Jamf mobile device $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
          return false;
       }
 
@@ -865,57 +754,10 @@ class PluginJamfMobileSync extends PluginJamfSync {
       return true;
    }
 
-   public static function syncAll(): int
+   protected static function getJamfDataForSyncingByGlpiItem(string $itemtype, int $items_id): array
    {
       global $DB;
 
-      $volume = 0;
-
-      $config = PluginJamfConfig::getConfig();
-      $mobiledevice = new PluginJamfMobileDevice();
-
-      self::syncExtensionAttributeDefinitions();
-      $iterator = $DB->request([
-         'SELECT' => ['id'],
-         'FROM' => PluginJamfMobileDevice::getTable(),
-         'WHERE' => [
-            new QueryExpression("sync_date < NOW() - INTERVAL {$config['sync_interval']} MINUTE")
-         ]
-      ]);
-      if (!$iterator->count()) {
-         return -1;
-      }
-      while ($data = $iterator->next()) {
-         try {
-            $mobiledevice->getFromDB($data['id']);
-            $result = self::sync($mobiledevice);
-            if ($result) {
-               $volume++;
-            }
-         } catch (Exception $e2) {
-            // Some other error
-         }
-      }
-      return $volume;
-   }
-
-   /**
-    * Updates as device from data received from the Jamf API. The item must already exist in GLPI and be linked.
-    * @param string $itemtype
-    * @param int $items_id
-    * @param bool $use_transaction True if a DB transaction should be used.
-    * @return bool True if the update was successful.
-    * @throws Exception Any exception that occurs during the update process.
-    */
-   public static function sync(string $itemtype, int $items_id, bool $use_transaction = true): bool
-   {
-      global $DB;
-
-      $item = new $itemtype();
-      if (!$item->getFromDB($items_id)) {
-         Toolbox::logError("Attempted to sync non-existent $itemtype with ID {$items_id}");
-         return false;
-      }
       $iterator = $DB->request([
          'SELECT' => ['udid'],
          'FROM'   => PluginJamfMobileDevice::getTable(),
@@ -926,51 +768,11 @@ class PluginJamfMobileSync extends PluginJamfSync {
       ]);
 
       if (!count($iterator)) {
-         return false;
+         return [];
       }
-      $jamfitem = $iterator->next();
+      $jamf_item = $iterator->next();
 
-      $data = PluginJamfAPIClassic::getItems('mobiledevices', ['udid' => $jamfitem['udid']]);
-      if ($data === null) {
-         // API error or device no longer exists in Jamf
-         return false;
-      }
-
-      try {
-         if ($use_transaction) {
-            $DB->beginTransaction();
-         }
-
-         $sync = new self($item, $data);
-         $sync_result = $sync->syncGeneral()
-            ->syncOS()
-            ->syncSoftware()
-            ->syncUser()
-            ->syncPurchasing()
-            ->syncExtensionAttributes()
-            ->syncSecurity()
-            ->syncNetwork()
-            ->syncComponents()
-            ->syncGeneralJamf()
-            ->finalizeSync();
-         // Evaluate final sync result. If any errors exist, count as failure.
-         // Any tasks that are still deferred are also counted as failures.
-         $failed = array_keys($sync_result, [self::STATUS_ERROR, self::STATUS_DEFERRED]);
-         if (count($failed) !== 0) {
-            throw new RuntimeException('One or more sync actions failed [' . implode(', ', $failed) . ']');
-         }
-
-         if ($use_transaction) {
-            $DB->commit();
-         }
-         return true;
-      } catch (Exception $e) {
-         Toolbox::logError($e->getMessage());
-         if ($use_transaction) {
-            $DB->rollBack();
-         }
-         throw $e;
-      }
+      return PluginJamfAPIClassic::getItems('mobiledevices', ['udid' => $jamf_item['udid']]);
    }
 
    public static function getSupportedGlpiItemtypes(): array


### PR DESCRIPTION
Added PluginJamfDeviceSync class between the computer and mobile device sync classes and the base PluginJamfSync class
 - The base sync class may be used for non-device item syncing in the future. Better to add that abstraction now.
 - Some mobile device and computer sync logic is shared and doesn't make sense outside of the context of device syncing. This is a good place to add it.

Renamed some variables in the sync engines to clarify they refer to the class/itemtype in the plugin and not Jamf.
 - Should reduce confusion if two-way syncing is supported in the future

Drop repeated dummySync flag checks in each device sync function. It should no longer be possible to call any sync function when the engine is constructed without valid parameters.
 - Sync is a static function that makes its own sync engine instance.
 - Any non-device sync engine is expected to implement syncing the same way or check the flag in the main sync function.