### PR TITLE
fix multiple calls of getCards hook

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -245,9 +245,11 @@ function plugin_jamf_getAddSearchOptions($itemtype)
    return $opt;
 }
 
-function plugin_jamf_dashboardCards()
+function plugin_jamf_dashboardCards($cards = [])
 {
-   $cards = [];
+   if (is_null($cards)) {
+      $cards = [];
+   }
    $cards = array_merge($cards, PluginJamfExtensionAttribute::dashboardCards());
    $cards = array_merge($cards, PluginJamfMobileDevice::dashboardCards());
 


### PR DESCRIPTION
when multiple plugins add cards to dashboards, only the last one (in alphabetical order) get its cards hooked.