### PR TITLE
Track model identifier

### DIFF
--- a/inc/computersync.class.php
+++ b/inc/computersync.class.php
@@ -640,7 +640,8 @@ class PluginJamfComputerSync extends PluginJamfDeviceSync
                 'items_id' => $items_id,
                 'udid' => $jamf_item['general']['udid'],
                 'jamf_type' => static::$jamf_itemtype,
-                'jamf_items_id' => $jamf_item['general']['id']
+                'jamf_items_id' => $jamf_item['general']['id'],
+                'model_identifier'  => $jamf_item['hardware']['model_identifier'],
             ]);
             if ($r === false) {
                 if ($use_transaction) {

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -37,7 +37,7 @@ class PluginJamfConfig extends CommonDBTM
         return '';
     }
 
-    public function showForm()
+    public function showForm($ID = -1, array $options = [])
     {
         global $CFG_GLPI;
         if (!Session::haveRight('config', UPDATE)) {

--- a/inc/mobilesync.class.php
+++ b/inc/mobilesync.class.php
@@ -787,7 +787,8 @@ class PluginJamfMobileSync extends PluginJamfDeviceSync
                 'items_id' => $items_id,
                 'udid' => $jamf_item['general']['udid'],
                 'jamf_type' => static::$jamf_itemtype,
-                'jamf_items_id' => $jamf_item['general']['id']
+                'jamf_items_id' => $jamf_item['general']['id'],
+                'model_identifer' => $jamf_item['general']['model_identifier'],
             ]);
             if ($r === false) {
                 if ($use_transaction) {

--- a/setup.php
+++ b/setup.php
@@ -20,9 +20,9 @@
  --------------------------------------------------------------------------
  */
 
-define('PLUGIN_JAMF_VERSION', '2.2.0');
-define('PLUGIN_JAMF_MIN_GLPI', '9.5.0');
-define('PLUGIN_JAMF_MAX_GLPI', '9.6.0');
+define('PLUGIN_JAMF_VERSION', '3.0.0');
+define('PLUGIN_JAMF_MIN_GLPI', '10.0.0');
+define('PLUGIN_JAMF_MAX_GLPI', '10.1.0');
 
 function plugin_init_jamf()
 {


### PR DESCRIPTION
The model identifier of devices is not currently tracked anywhere in GLPI but would be required for some things like filtering the list of updates for ScheduleOSUpdate command to show available updates applicable to the device.

The migration process will retroactively fill this data from the JSS API for all devices currently imported.
For new devices, the data will be added during import.