### PR TITLE
Allow null udid for computers during discovery

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -603,4 +603,10 @@ final class PluginJamfMigration
             'state'     => CronTask::STATE_WAITING,
         ]);
     }
+
+    public function apply_3_0_1_migration(): void
+    {
+        // Change udid column in glpi_plugin_jamf_imports to allow NULL values
+        $this->db->queryOrDie('ALTER TABLE `glpi_plugin_jamf_imports` MODIFY `udid` VARCHAR(100) NULL DEFAULT NULL');
+    }
 }


### PR DESCRIPTION
The basic API query used to discover computers does not include a udid property. The sync engine already handled this case properly, but the DB schema wasn't configured to allow the storage of null values in this column.