### PR TITLE
Replace Atoum with PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+tests/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,22 +3,27 @@
     {
       "type": "vcs",
       "url": "https://github.com/cconard96/tools"
+    },
+    {
+      "type": "vcs",
+        "url": "https://github.com/CJDevStudios/atoum-phpunit-shim"
     }
   ],
   "require": {
-    "php": "^7.4"
+    "php": "^7.4|^8.0"
   },
   "require-dev": {
+    "cjdevstudios/atoum-phpunit-shim": "dev-main",
     "glpi-project/tools": "dev-debug/master"
   },
   "config": {
     "optimize-autoloader": true,
-    "platform": {
-      "php": "7.4.0"
-    },
     "sort-packages": true,
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": false
     }
+  },
+  "scripts": {
+    "test": "phpunit -c tests/phpunit.xml"
   }
 }

--- a/tests/abstractdbtest.class.php
+++ b/tests/abstractdbtest.class.php
@@ -40,6 +40,30 @@ abstract class AbstractDBTest extends \CJDevStudios\AtoumShim\Atoum
         $PHPLOGGER->setHandlers([static::$php_log_handler]);
         static::$sql_log_handler = new TestHandler(LogLevel::DEBUG);
         $SQLLOGGER->setHandlers([static::$sql_log_handler]);
+
+        $default_config = [
+            'autoimport' => 0,
+            'sync_general' => 1,
+            'sync_components' => 1,
+            'sync_financial' => 1,
+            'sync_os' => 1,
+            'sync_software' => 1,
+            'sync_user' => 1,
+            'ipad_type' => 0,
+            'iphone_type' => 0,
+            'appletv_type' => 0,
+            'default_manufacturer' => 0,
+        ];
+        foreach ($default_config as $name => $value) {
+            $DB->updateOrInsert('glpi_configs', [
+                'value' => $value,
+                'context' => 'plugin:Jamf',
+                'name' => $name,
+            ], [
+                'context' => 'plugin:Jamf',
+                'name' => $name,
+            ]);
+        }
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/abstractdbtest.class.php
+++ b/tests/abstractdbtest.class.php
@@ -1,0 +1,292 @@
+<?php
+
+use Glpi\Tests\Log\TestHandler;
+use Glpi\Toolbox\Sanitizer;
+use Psr\Log\LogLevel;
+
+/**
+ * Mimics the DBTestCase class from GLPI but allows using the Atoum shim test class
+ */
+abstract class AbstractDBTest extends \CJDevStudios\AtoumShim\Atoum
+{
+    private int $int;
+
+    private string $str;
+
+    /**
+     * @var TestHandler
+     */
+    private static TestHandler $php_log_handler;
+
+    /**
+     * @var TestHandler
+     */
+    private static TestHandler $sql_log_handler;
+
+    public static function setUpBeforeClass(): void
+    {
+        global $DB;
+        $DB->beginTransaction();
+        static::resetSession();
+
+        // Ensure cache is clear
+        global $GLPI_CACHE;
+        $GLPI_CACHE->clear();
+
+        // Init log handlers
+        global $PHPLOGGER, $SQLLOGGER;
+        /** @var Monolog\Logger $PHPLOGGER */
+        static::$php_log_handler = new TestHandler(LogLevel::DEBUG);
+        $PHPLOGGER->setHandlers([static::$php_log_handler]);
+        static::$sql_log_handler = new TestHandler(LogLevel::DEBUG);
+        $SQLLOGGER->setHandlers([static::$sql_log_handler]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        global $DB;
+        $DB->rollback();
+    }
+
+    protected static function resetSession()
+    {
+        Session::destroy();
+        Session::start();
+
+        $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+        $_SESSION['glpiactive_entity'] = 0;
+
+        global $CFG_GLPI;
+        foreach ($CFG_GLPI['user_pref_field'] as $field) {
+            if (!isset($_SESSION["glpi$field"]) && isset($CFG_GLPI[$field])) {
+                $_SESSION["glpi$field"] = $CFG_GLPI[$field];
+            }
+        }
+    }
+
+    /**
+     * Get a unique random string
+     */
+    protected function getUniqueString()
+    {
+        if (is_null($this->str)) {
+            return $this->str = uniqid('str', false);
+        }
+        return $this->str .= 'x';
+    }
+
+    /**
+     * Get a unique random integer
+     */
+    protected function getUniqueInteger()
+    {
+        if (is_null($this->int)) {
+            return $this->int = random_int(1000, 10000);
+        }
+        return $this->int++;
+    }
+
+    /**
+     * Connect (using the test user per default)
+     *
+     * @param string $user_name User name (defaults to TU_USER)
+     * @param string $user_pass user password (defaults to TU_PASS)
+     * @param bool $noauto disable autologin (from CAS by example)
+     * @param bool $expected bool result expected from login return
+     *
+     * @return \Auth
+     */
+    protected function login(
+        string $user_name = TU_USER,
+        string $user_pass = TU_PASS,
+        bool $noauto = true,
+        bool $expected = true
+    ): \Auth {
+        \Session::destroy();
+        \Session::start();
+
+        $auth = new Auth();
+        $this->boolean($auth->login($user_name, $user_pass, $noauto))->isEqualTo($expected);
+
+        return $auth;
+    }
+
+    /**
+     * Log out current user
+     *
+     * @return void
+     */
+    protected function logOut()
+    {
+        $ctime = $_SESSION['glpi_currenttime'];
+        \Session::destroy();
+        $_SESSION['glpi_currenttime'] = $ctime;
+    }
+
+    /**
+     * change current entity
+     *
+     * @param int|string $entityname Name of the entity (or its id)
+     * @param boolean $subtree   Recursive load
+     *
+     * @return void
+     */
+    protected function setEntity($entityname, $subtree)
+    {
+        $entity_id = is_int($entityname) ? $entityname : getItemByTypeName('Entity', $entityname, true);
+        $res = Session::changeActiveEntities($entity_id, $subtree);
+        $this->boolean($res)->isTrue();
+    }
+
+    /**
+     * Generic method to test if an added object is corretly inserted
+     *
+     * @param  Object $object The object to test
+     * @param  int    $id     The id of added object
+     * @param  array  $input  the input used for add object (optionnal)
+     *
+     * @return void
+     */
+    protected function checkInput(CommonDBTM $object, $id = 0, $input = [])
+    {
+        $input = Sanitizer::dbUnescapeRecursive($input); // slashes in input should not be stored in DB
+
+        $this->integer((int)$id)->isGreaterThan(0);
+        $this->boolean($object->getFromDB($id))->isTrue();
+        $this->variable($object->getField('id'))->isEqualTo($id);
+
+        if (count($input)) {
+            foreach ($input as $k => $v) {
+                $this->variable($object->fields[$k])->isEqualTo(
+                    $v,
+                    "
+                '$k' key current value '{$object->fields[$k]}' (" . gettype($object->fields[$k]) . ")
+                is not equal to '$v' (" . gettype($v) . ")"
+                );
+            }
+        }
+    }
+
+    /**
+     * Get all classes in folder inc/
+     *
+     * @param boolean $function Whether to look for a function
+     * @param array   $excludes List of classes to exclude
+     *
+     * @return array
+     */
+    protected function getClasses($function = false, array $excludes = [])
+    {
+        // Add deprecated classes to excludes to prevent test failure
+        $excludes = array_merge(
+            $excludes,
+            [
+                'TicketFollowup', // Deprecated
+                '/^RuleImportComputer.*/', // Deprecated
+            ]
+        );
+
+        $files_iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(GLPI_ROOT . '/src'),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        $classes = [];
+        foreach ($files_iterator as $fileInfo) {
+            if ($fileInfo->getExtension() !== 'php') {
+                continue;
+            }
+
+            $classname = $fileInfo->getBasename('.php');
+
+            $is_excluded = false;
+            foreach ($excludes as $exclude) {
+                if ($classname === $exclude || @preg_match($exclude, $classname) === 1) {
+                    $is_excluded = true;
+                    break;
+                }
+            }
+            if ($is_excluded) {
+                continue;
+            }
+
+            if (!class_exists($classname)) {
+                continue;
+            }
+            $reflectionClass = new ReflectionClass($classname);
+            if ($reflectionClass->isAbstract()) {
+                continue;
+            }
+
+            if ($function) {
+                if (method_exists($classname, $function)) {
+                    $classes[] = $classname;
+                }
+            } else {
+                $classes[] = $classname;
+            }
+        }
+        return array_unique($classes);
+    }
+
+    /**
+     * Create an item of the given class
+     *
+     * @param string $itemtype
+     * @param array $input
+     * @param array $skip_fields Fields that wont be checked after creation
+     *
+     * @return CommonDBTM
+     */
+    protected function createItem($itemtype, $input, $skip_fields = []): CommonDBTM
+    {
+        $item = new $itemtype();
+        $input = Sanitizer::sanitize($input);
+        $id = $item->add($input);
+        $this->integer($id)->isGreaterThan(0);
+
+        // Remove special fields
+        $input = array_filter($input, function ($key) use ($skip_fields) {
+            return !in_array($key, $skip_fields) && strpos($key, '_') !== 0;
+        }, ARRAY_FILTER_USE_KEY);
+
+        $this->checkInput($item, $id, $input);
+
+        return $item;
+    }
+
+    /**
+     * Create an item of the given class
+     *
+     * @param string $itemtype
+     * @param array $input
+     */
+    protected function updateItem($itemtype, $id, $input)
+    {
+        $item = new $itemtype();
+        $input['id'] = $id;
+        $input = Sanitizer::sanitize($input);
+        $success = $item->update($input);
+        $this->boolean($success)->isTrue();
+
+        // Remove special fields
+        $input = array_filter($input, function ($key) {
+            return strpos($key, '_') !== 0;
+        }, ARRAY_FILTER_USE_KEY);
+
+        $this->checkInput($item, $id, $input);
+    }
+
+    /**
+     * Create multiples items of the given class
+     *
+     * @param string $itemtype
+     * @param array $inputs
+     */
+    protected function createItems($itemtype, $inputs)
+    {
+        foreach ($inputs as $input) {
+            $this->createItem($itemtype, $input);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,12 +4,17 @@ global $CFG_GLPI;
 define('GLPI_ROOT', dirname(dirname(dirname(__DIR__))));
 define("GLPI_CONFIG_DIR", GLPI_ROOT . "/tests");
 
+if (file_exists("vendor/autoload.php")) {
+    require_once "vendor/autoload.php";
+}
+require_once "vendor/cjdevstudios/atoum-phpunit-shim/src/bootstrap.php";
 include GLPI_ROOT . "/inc/includes.php";
-include_once GLPI_ROOT . '/tests/GLPITestCase.php';
-include_once GLPI_ROOT . '/tests/DbTestCase.php';
+//include_once GLPI_ROOT . '/tests/GLPITestCase.php';
+//include_once GLPI_ROOT . '/tests/DbTestCase.php';
+include "tests/abstractdbtest.class.php";
 
 $plugin = new Plugin();
-$plugin->checkStates(true);
+//$plugin->checkStates(true);
 $plugin->getFromDBbyDir('jamf');
 
 if (!plugin_jamf_check_prerequisites()) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ include GLPI_ROOT . "/inc/includes.php";
 include "tests/abstractdbtest.class.php";
 
 $plugin = new Plugin();
-//$plugin->checkStates(true);
+$plugin->checkPluginState('jamf');
 $plugin->getFromDBbyDir('jamf');
 
 if (!plugin_jamf_check_prerequisites()) {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php">
+    <testsuite name='Jamf Plugin Tests'>
+        <directory suffix='.php'>./units/</directory>
+    </testsuite>
+</phpunit>

--- a/tests/units/PluginJamfComputerSync.php
+++ b/tests/units/PluginJamfComputerSync.php
@@ -23,14 +23,14 @@
 
 namespace tests\units;
 
-use DbTestCase;
+use AbstractDBTest;
 use PluginJamfComputer;
 use PluginJamfComputerTestSync;
 use PluginJamfExtensionAttribute;
 use PluginJamfImport;
 use PluginJamfItem_ExtensionAttribute;
 
-class PluginJamfComputerSync extends DbTestCase {
+class PluginJamfComputerSync extends AbstractDBTest {
 
     public function testDiscover() {
         global $DB;

--- a/tests/units/PluginJamfMobileSync.php
+++ b/tests/units/PluginJamfMobileSync.php
@@ -23,7 +23,7 @@
 
 namespace tests\units;
 
-use DbTestCase;
+use AbstractDBTest;
 use Phone;
 use PluginJamfAbstractDevice;
 use PluginJamfExtensionAttribute;
@@ -35,7 +35,7 @@ use PluginJamfMobileTestSync;
 use PluginJamfSync;
 use ReflectionClass;
 
-class PluginJamfMobileSync extends DbTestCase {
+class PluginJamfMobileSync extends AbstractDBTest {
 
     public function testDiscover() {
         global $DB;


### PR DESCRIPTION
Replace Atoum with PHPUnit for tests.

Initially, a shim library will be used to allow running the existing Atoum tests in the PHPUnit engine so I don't have to work with the Atoum engine anymore.
Next, tests will be fixed.
Finally, the Atoum assertions will be changed to the native PHPUnit equivalents and the shim will be dropped and replaced with just PHPUnit. A GitHub action will also be added to automatically run the test suite for pull requests.